### PR TITLE
add universal_newlines param to Popen to work in python 3

### DIFF
--- a/drain/util.py
+++ b/drain/util.py
@@ -452,7 +452,7 @@ class PgSQLDatabase(pandas.io.sql.SQLDatabase):
 
         sql = "COPY {table_name} ({columns}) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)".format(
                 table_name=table_name, columns=columns)
-        p = Popen(['psql', '-c', sql], stdout=PIPE, stdin=PIPE, stderr=STDOUT, 
+        p = Popen(['psql', '-c', sql], stdout=PIPE, stdin=PIPE, stderr=STDOUT,
                   universal_newlines=True)
         frame.to_csv(p.stdin, index=index)
 

--- a/drain/util.py
+++ b/drain/util.py
@@ -452,11 +452,11 @@ class PgSQLDatabase(pandas.io.sql.SQLDatabase):
 
         sql = "COPY {table_name} ({columns}) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)".format(
                 table_name=table_name, columns=columns)
-        p = Popen(['psql', '-c', sql], stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+        p = Popen(['psql', '-c', sql], stdout=PIPE, stdin=PIPE, stderr=STDOUT, universal_newlines=True)
         frame.to_csv(p.stdin, index=index)
 
         psql_out = p.communicate()[0]
-        logging.info(psql_out.decode()),
+        logging.info(psql_out),
 
         r = p.wait()
         if raise_on_error and (r > 0):

--- a/drain/util.py
+++ b/drain/util.py
@@ -452,7 +452,8 @@ class PgSQLDatabase(pandas.io.sql.SQLDatabase):
 
         sql = "COPY {table_name} ({columns}) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)".format(
                 table_name=table_name, columns=columns)
-        p = Popen(['psql', '-c', sql], stdout=PIPE, stdin=PIPE, stderr=STDOUT, universal_newlines=True)
+        p = Popen(['psql', '-c', sql], stdout=PIPE, stdin=PIPE, stderr=STDOUT, 
+                  universal_newlines=True)
         frame.to_csv(p.stdin, index=index)
 
         psql_out = p.communicate()[0]


### PR DESCRIPTION
The `universal_newlines` parameter allows Popen to accept string input in python 3.