### PR TITLE
Streamline exploration

### DIFF
--- a/drain/__init__.py
+++ b/drain/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from . import serialize
+from .exploration import explore  # noqa: F401
 
 logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=0)
 

--- a/drain/exploration.py
+++ b/drain/exploration.py
@@ -7,8 +7,11 @@ import pandas as pd
 from collections import Counter
 from six import StringIO
 
-
 from drain import util, step
+
+
+def explore(steps, reload=False):
+    return StepFrame(index=step.load(steps, reload=reload))
 
 
 def expand(self, prefix=False, index=True, diff=True, existence=True):
@@ -223,6 +226,9 @@ class StepFrame(pd.DataFrame):
     @property
     def _contructor_sliced(self):
         return pd.Series
+
+    def __str__(self):
+        return self.expand().__str__()
 
     # resetting index makes it no longer a StepFrame
     def reset_index(self, *args, **kwargs):

--- a/drain/exploration.py
+++ b/drain/exploration.py
@@ -251,6 +251,9 @@ class StepSeries(pd.Series):
     def _contructor_expanddim(self):
         return StepFrame
 
+    def __str__(self):
+        return self.expand().__str__()
+
     def reset_index(self, *args, **kwargs):
         return pd.Series(self).reset_index(*args, **kwargs)
 

--- a/drain/step.py
+++ b/drain/step.py
@@ -22,14 +22,14 @@ import drain
 _STEP_CACHE = {}
 
 
-def load(steps, reset=False):
+def load(steps, reload=False):
     """
     safely load steps in place, excluding those that fail
     Args:
         steps: the steps to load
     """
     # work on collections by default for fewer isinstance() calls per call to load()
-    if reset:
+    if reload:
         _STEP_CACHE.clear()
 
     if callable(steps):

--- a/drain/step.py
+++ b/drain/step.py
@@ -18,21 +18,22 @@ from tables import NaturalNameWarning
 from drain import util
 import drain
 
+_step_dict = {}
 
-def load(steps):
+
+def load(steps, _step_dict=_step_dict):
     """
     safely load steps, excluding those that fail
     """
-    loaded = []
-    for s in steps:
-        try:
-            s.load()
-            loaded.append(s)
-        except:
-            logging.warn('Error during step load:\n%s' %
-                         util.indent(traceback.format_exc()))
-            pass
-    return loaded
+    for i, s in enumerate(steps):
+        if s in _step_dict:
+            steps[i] = _step_dict[s]
+        else:
+            try:
+                s.load()
+            except:
+                logging.warn('Error during step load:\n%s' %
+                             util.indent(traceback.format_exc()))
 
 
 class Step(object):

--- a/drain/step.py
+++ b/drain/step.py
@@ -40,7 +40,7 @@ def load(steps, reload=False):
 
     # iterate in reverse
     # so popping failed steps doesn't affect list indices subsequent list access
-    for i, s in reversed(enumerate(steps)):
+    for i, s in enumerate(reversed(steps)):
         digest = s._digest
         if digest in _STEP_CACHE:
             steps[i] = _STEP_CACHE[digest]

--- a/tests/test_drain.py
+++ b/tests/test_drain.py
@@ -59,14 +59,7 @@ def calibration():
         cal_est = model.FitPredict(inputs=[cal, d])
         cal_est.target = True
 
-        metrics = model.PrintMetrics(metrics=[
-                {'metric':'baseline'},
-                {'metric':'precision', 'k':100},
-                {'metric':'precision', 'k':200},
-                {'metric':'precision', 'k':300},
-        ], inputs=[cal_est])
-
-        steps.append(metrics)
+        steps.append(cal_est)
 
     return steps
 


### PR DESCRIPTION
A few changes to make exploration more streamlined.

First and foremost, use a global step cache. This means that a given step's results are only loaded once (unless the cache is reset). Makes exploration of multiple, overlapping workflows much more efficient. Also good for reloading steps failed runs.

Minor changes:
 - rename `drain.explore` to `drain.exploration`
 - add `drain.explore` (which is an alias for `drain.exploration.explore`) which is the composition of `StepFrame` and `drain.explore(index=)`
 - override `StepFrame.__str__` to `expand()` automatically

The point is you can now do:
```python
>>> import drain
>>> from drain import model
>>> from test_drain import n_estimators_search
>>> drain.explore(n_estimators_search)\
         .dapply(model.precision, k=[50,100,200])
k              100    200       300
n_estimators                       
1             0.81  0.840  0.836667
2             0.82  0.845  0.713333
3             0.90  0.815  0.723333
```
And future calls to `explore(n_estimators_search)` will not reload those results.